### PR TITLE
My proposed changes to RNA-seq PE

### DIFF
--- a/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
+++ b/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Add featureCounts as an alternative way to generate count files
 - Use fastp instead of cutadapt which uses pair overlap and allows to have optional adapter sequences
 
+### Tool update
+- `toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.3` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.4`
+
 ### Test dataset
 - Using a new subsampled Yeast test data from Zenodo record https://zenodo.org/records/13987631
 

--- a/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
+++ b/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## [0.10] 2024-09-23
+## [1.0] 2024-09-23
 
-### Manual update
+### Changes in workflows
+- Add an optional subworkflow with more QC: FastQC, Picard, Read distribution on genomic features, gene body coverage, reads per chromosomes.
+- Add featureCounts as an alternative way to generate count files
+- Use fastp instead of cutadapt which uses pair overlap and allows to have optional adapter sequences
+
+### Test dataset
 - Using a new subsampled Yeast test data from Zenodo record https://zenodo.org/records/13987631
-- Added a subworkflow with MultiQC on FastQC, Cutadapt, STAR, featureCounts and Picard reports
-- Added featureCounts as an alternative way to generate count files
 
 ## [0.9] 2024-09-23
 

--- a/workflows/transcriptomics/rnaseq-pe/README.md
+++ b/workflows/transcriptomics/rnaseq-pe/README.md
@@ -15,8 +15,8 @@ chrM	chrM_gene	exon	0	16299	.	-	.	gene_id "chrM_gene_minus"; transcript_id "chrM
 
 ## Inputs values
 
-- Forward and Reverse adapter: this depends on the library preparation. Usually classical Illumina RNA libraries are Truseq and ISML (relatively new Illumina library) is Nextera. If you don't know, use FastQC to determine if it is Truseq or Nextera. If the read length is relatively short (50bp), there is probably no adapter so it will not impact your results.
-- Generate QC reports: whether to generate an aggrigated MultiQC report from FastQC, Cutadapt, STAR, featureCounts and Picard.
+- Forward and Reverse adapter (optional): By default, fastp will try to overlap both reads and will only use these sequences if R1/R2 are found not overlapped. Their sequences depends on the library preparation. Usually classical Illumina RNA libraries is Truseq and ISML (relatively new Illumina library) is Nextera.
+- Generate additional QC reports: whether to compute additional QC: FastQC, Picard, Read distribution on genomic features, gene body coverage, reads per chromosomes.
 - Reference genome: this field will be adapted to the genomes available for STAR.
 - Strandedness: For stranded RNA, reverse means that the first read in a pair is complementary to the coding sequence, forward means that the first read in a pair is in the same orientation as the coding sequence. This will only count alignments that are compatible with your library preparation strategy. This is also used for the stranded coverage and for FPKM computation with cufflinks/StringTie.
 - Use featureCounts for generating count tables: Whether to use count tables from featureCounts instead of from STAR.
@@ -28,9 +28,10 @@ chrM	chrM_gene	exon	0	16299	.	-	.	gene_id "chrM_gene_minus"; transcript_id "chrM
 - The workflow will remove adapters and low quality bases and filter out any read smaller than 15bp.
 - The filtered reads are mapped with STAR with ENCODE parameters (for long RNA-seq but I use it for short also). STAR is also used to count reads per gene and generate strand-specific normalized coverage (on uniquely mapped reads).
 - Optionally featureCounts is used to generate count files when this option enabled.
+- Optionally FastQC, Picard, read_distribution, geneBody_coverage, samtools idxstats, Picard are run to get additional QC.
 - A multiQC is run to have an overview of the QC. This can also be used to get the strandedness.
 - FPKM values for genes and transcripts are computed with cufflinks using correction for multi-mapped reads (this step is optionnal).
-- FPKM/TPM values for genes are computed with StringTie.
+- FPKM/TPM values for genes are computed with StringTie (this step is optional).
 - The BAM is filtered to keep only uniquely mapped reads (tag NH:i:1).
 - Unstranded coverage is computed with bedtools and normalized to the number of million uniquely mapped reads.
 - The three coverage files are converted to bigwig.

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
@@ -20,7 +20,7 @@
           location: https://zenodo.org/records/13987631/files/SRR5085167_reverse.fastqsanger.gz
     Forward adapter: AGATCGGAAGAG
     Reverse adapter: GATCGTCGGACT
-    Generate QC reports: true
+    Generate additional QC reports: true
     Reference genome: sacCer3
     Use featureCounts for generating count tables: true
     Strandedness: stranded - forward
@@ -84,9 +84,3 @@
           asserts:
             has_line:
               line: "YAL038W	1609"
-    FeatureCounts Summary Table:
-      element_tests:
-        SRR5085167:
-          asserts:
-            has_line:
-              line: "Assigned	101987"

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
@@ -37,13 +37,15 @@
     Stranded Coverage:
       element_tests:
         SRR5085167_forward:
-          has_size:
-            value: 635210
-            delta: 30000
+          asserts:
+            has_size:
+              value: 635210
+              delta: 30000
         SRR5085167_reverse:
-          has_size:
-            value: 618578
-            delta: 30000
+          asserts:
+            has_size:
+              value: 618578
+              delta: 30000
     Gene Abundance Estimates from StringTie:
       element_tests:
         SRR5085167:
@@ -53,15 +55,17 @@
     Unstranded Coverage:
       element_tests:
         SRR5085167:
-          has_size:
-            value: 1140004
-            delta: 50000
+          asserts:
+            has_size:
+              value: 1140004
+              delta: 50000
     Mapped Reads:
       element_tests:
         SRR5085167:
-          has_size:
-            value: 56913572
-            delta: 2500000
+          asserts:
+            has_size:
+              value: 56913572
+              delta: 2500000
     Genes Expression from Cufflinks:
       element_tests:
         SRR5085167:

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
@@ -1,12 +1,12 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with cutadapt. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.\n",
+    "annotation": "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with fastp. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.\n",
     "comments": [
         {
             "child_steps": [
-                13,
-                21,
-                22
+                14,
+                22,
+                23
             ],
             "color": "yellow",
             "data": {
@@ -25,9 +25,9 @@
         },
         {
             "child_steps": [
-                14,
                 15,
-                16
+                16,
+                17
             ],
             "color": "lime",
             "data": {
@@ -46,8 +46,8 @@
         },
         {
             "child_steps": [
-                18,
-                19
+                19,
+                20
             ],
             "color": "red",
             "data": {
@@ -80,7 +80,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "release": "0.10",
-    "name": "RNAseq_PE",
+    "name": "RNA-seq for Paired-end fastqs",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -101,7 +101,7 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 0.0,
+                "left": 0,
                 "top": 462.87500890145213
             },
             "tool_id": null,
@@ -113,14 +113,14 @@
             "workflow_outputs": []
         },
         "1": {
-            "annotation": "Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
+            "annotation": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC, for TruSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
             "content_id": null,
             "errors": null,
             "id": 1,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
+                    "description": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC, for TruSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
                     "name": "Forward adapter"
                 }
             ],
@@ -132,7 +132,7 @@
                 "top": 567.328103383874
             },
             "tool_id": null,
-            "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "6d1de206-97c4-41ba-8702-a980f748a689",
@@ -140,14 +140,14 @@
             "workflow_outputs": []
         },
         "2": {
-            "annotation": "Please use: For R2: - For Nextera: CTGTCTCTTATACACATCTGACGCTGCCGACGA - For TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
+            "annotation": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTGACGCTGCCGACGA, for TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
             "content_id": null,
             "errors": null,
             "id": 2,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "Please use: For R2: - For Nextera: CTGTCTCTTATACACATCTGACGCTGCCGACGA - For TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
+                    "description": "This is optional. Fastp will use overlapping. If you want to specify, for Nextera use: CTGTCTCTTATACACATCTGACGCTGCCGACGA, for TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
                     "name": "Reverse adapter"
                 }
             ],
@@ -159,7 +159,7 @@
                 "top": 667.4062589014521
             },
             "tool_id": null,
-            "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "7aae38b8-39a8-4fba-bc6b-bda8c1ea9162",
@@ -167,18 +167,18 @@
             "workflow_outputs": []
         },
         "3": {
-            "annotation": "Whether to report QC",
+            "annotation": "Whether to compute additional QC like fastQC, gene body coverage etc...",
             "content_id": null,
             "errors": null,
             "id": 3,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "Whether to report QC",
-                    "name": "Generate QC reports"
+                    "description": "Whether to compute additional QC like fastQC, gene body coverage etc...",
+                    "name": "Generate additional QC reports"
                 }
             ],
-            "label": "Generate QC reports",
+            "label": "Generate additional QC reports",
             "name": "Input parameter",
             "outputs": [],
             "position": {
@@ -406,7 +406,13 @@
                 "left": 430.77112544776327,
                 "top": 623.8873433527641
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
             "tool_id": "__FLATTEN__",
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"join_identifier\": \"_\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
@@ -417,81 +423,126 @@
         },
         "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy2",
             "errors": null,
             "id": 12,
             "input_connections": {
-                "library|input_1": {
-                    "id": 0,
-                    "output_name": "output"
-                },
-                "library|r1|adapters_0|adapter_source|adapter": {
+                "single_paired|adapter_trimming_options|adapter_sequence1": {
                     "id": 1,
                     "output_name": "output"
                 },
-                "library|r2|adapters2_0|adapter_source|adapter": {
+                "single_paired|adapter_trimming_options|adapter_sequence2": {
                     "id": 2,
+                    "output_name": "output"
+                },
+                "single_paired|paired_input": {
+                    "id": 0,
                     "output_name": "output"
                 }
             },
             "inputs": [
                 {
-                    "description": "runtime parameter for tool Cutadapt",
-                    "name": "library"
+                    "description": "runtime parameter for tool fastp",
+                    "name": "single_paired"
                 }
             ],
-            "label": "Cutadapt (remove adapter + bad quality bases)",
-            "name": "Cutadapt",
+            "label": "remove adapters + bad quality bases",
+            "name": "fastp",
             "outputs": [
                 {
-                    "name": "out_pairs",
+                    "name": "output_paired_coll",
                     "type": "input"
                 },
                 {
-                    "name": "report",
-                    "type": "txt"
+                    "name": "report_json",
+                    "type": "json"
                 }
             ],
             "position": {
-                "left": 382.52212406111795,
-                "top": 267.76267157128495
+                "left": 392.6147686047791,
+                "top": 201.9284685268642
             },
             "post_job_actions": {
-                "HideDatasetActionout1": {
+                "HideDatasetActionoutput_paired_coll": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "out1"
+                    "output_name": "output_paired_coll"
                 },
-                "HideDatasetActionout_pairs": {
+                "HideDatasetActionreport_json": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "out_pairs"
-                },
-                "HideDatasetActionreport": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "report"
+                    "output_name": "report_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.9+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "5eb7e84243f2",
-                "name": "cutadapt",
-                "owner": "lparsons",
+                "changeset_revision": "dbfc505896e9",
+                "name": "fastp",
+                "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adapter_options\": {\"action\": \"trim\", \"error_rate\": \"0.1\", \"no_indels\": false, \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": false, \"no_match_adapter_wildcards\": true, \"revcomp\": false}, \"filter_options\": {\"discard_trimmed\": false, \"discard_untrimmed\": false, \"minimum_length\": \"15\", \"minimum_length2\": null, \"maximum_length\": null, \"maximum_length2\": null, \"max_n\": null, \"max_expected_errors\": null, \"max_average_error_rate\": null, \"discard_casava\": false, \"pair_filter\": \"any\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC\", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": false}], \"front_adapters\": [], \"anywhere_adapters\": []}, \"r2\": {\"adapters2\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R2: - For Nextera: CTGTCTCTTATACACATCTGACGCTGCCGACGA - For TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT\", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": false}], \"front_adapters2\": [], \"anywhere_adapters2\": []}, \"pair_adapters\": false}, \"other_trimming_options\": {\"cut\": \"0\", \"cut2\": \"0\", \"quality_cutoff\": \"30\", \"quality_cutoff2\": \"\", \"nextseq_trim\": \"0\", \"trim_n\": false, \"poly_a\": false, \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"shorten_options_r2\": {\"shorten_values_r2\": \"False\", \"__current_case__\": 1}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"strip_suffix\": \"\", \"length_tag\": \"\", \"rename\": \"\", \"zero_cap\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.9+galaxy1",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": \"30\", \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": \"15\", \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": false, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": {\"__class__\": \"ConnectedValue\"}, \"adapter_sequence2\": {\"__class__\": \"ConnectedValue\"}, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.23.4+galaxy2",
             "type": "tool",
-            "uuid": "86b5b52b-cf40-4d34-9b60-7ede0e187b4f",
+            "uuid": "80d855a6-7a77-46e9-9124-9dd3d9d72cc1",
             "when": null,
             "workflow_outputs": []
         },
         "13": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
             "id": 13,
+            "input_connections": {
+                "input_param_type|input_param": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map parameter value",
+                    "name": "input_param_type"
+                }
+            ],
+            "label": "no additional QC",
+            "name": "Map parameter value",
+            "outputs": [
+                {
+                    "name": "output_param_boolean",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 2159.2104562234385,
+                "top": 23.726446900364408
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_param_boolean": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "5ac8a4bf7a8d",
+                "name": "map_param_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"true\"}, {\"__index__\": 1, \"from\": true, \"to\": \"false\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "fd5cb0a4-a2a4-4677-8a1d-e81e1043533b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 14,
             "input_connections": {
                 "components_0|param_type|component_value": {
                     "id": 4,
@@ -532,11 +583,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "14": {
+        "15": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 14,
+            "id": 15,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 6,
@@ -582,11 +633,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "15": {
+        "16": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 15,
+            "id": 16,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 6,
@@ -632,11 +683,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "16": {
+        "17": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 16,
+            "id": 17,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 6,
@@ -682,11 +733,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "17": {
+        "18": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.7.11a+galaxy1",
             "errors": null,
-            "id": 17,
+            "id": 18,
             "input_connections": {
                 "refGenomeSource|GTFconditional|genomeDir": {
                     "id": 4,
@@ -698,7 +749,7 @@
                 },
                 "singlePaired|input": {
                     "id": 12,
-                    "output_name": "out_pairs"
+                    "output_name": "output_paired_coll"
                 }
             },
             "inputs": [
@@ -748,6 +799,16 @@
                 "top": 246.8799136582777
             },
             "post_job_actions": {
+                "HideDatasetActionoutput_log": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_log"
+                },
+                "HideDatasetActionreads_per_gene": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "reads_per_gene"
+                },
                 "HideDatasetActionsignal_unique_str1": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -808,17 +869,17 @@
                 }
             ]
         },
-        "18": {
+        "19": {
             "annotation": "",
-            "id": 18,
+            "id": 19,
             "input_connections": {
                 "STAR BAM": {
-                    "id": 17,
+                    "id": 18,
                     "input_subworkflow_step_id": 1,
                     "output_name": "mapped_reads"
                 },
                 "STAR log": {
-                    "id": 17,
+                    "id": 18,
                     "input_subworkflow_step_id": 0,
                     "output_name": "output_log"
                 }
@@ -1167,17 +1228,17 @@
                 }
             ]
         },
-        "19": {
+        "20": {
             "annotation": "",
-            "id": 19,
+            "id": 20,
             "input_connections": {
                 "Bedgraph strand 1": {
-                    "id": 17,
+                    "id": 18,
                     "input_subworkflow_step_id": 1,
                     "output_name": "signal_unique_str1"
                 },
                 "Bedgraph strand 2": {
-                    "id": 17,
+                    "id": 18,
                     "input_subworkflow_step_id": 2,
                     "output_name": "signal_unique_str2"
                 },
@@ -1754,14 +1815,14 @@
                 }
             ]
         },
-        "20": {
+        "21": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/2.0.3+galaxy2",
             "errors": null,
-            "id": 20,
+            "id": 21,
             "input_connections": {
                 "alignment": {
-                    "id": 17,
+                    "id": 18,
                     "output_name": "mapped_reads"
                 },
                 "anno|reference_gene_sets": {
@@ -1769,7 +1830,7 @@
                     "output_name": "output"
                 },
                 "strand_specificity": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "output_param_text"
                 },
                 "when": {
@@ -1799,7 +1860,18 @@
                 "left": 1713.913195680125,
                 "top": 672.9994811085061
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActionoutput_short": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_short"
+                },
+                "HideDatasetActionoutput_summary": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_summary"
+                }
+            },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/2.0.3+galaxy2",
             "tool_shed_repository": {
                 "changeset_revision": "f9d49f5cb597",
@@ -1814,22 +1886,22 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "21": {
+        "22": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/2.2.3+galaxy0",
             "errors": null,
-            "id": 21,
+            "id": 22,
             "input_connections": {
                 "guide|guide_source|ref_hist": {
                     "id": 5,
                     "output_name": "output"
                 },
                 "input_options|input_bam": {
-                    "id": 17,
+                    "id": 18,
                     "output_name": "mapped_reads"
                 },
                 "rna_strandness": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "output_param_text"
                 },
                 "when": {
@@ -1897,14 +1969,14 @@
                 }
             ]
         },
-        "22": {
+        "23": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.3",
             "errors": null,
-            "id": 22,
+            "id": 23,
             "input_connections": {
                 "advanced_settings|library_type": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "output_param_text"
                 },
                 "advanced_settings|mask_file": {
@@ -1912,11 +1984,11 @@
                     "output_name": "output"
                 },
                 "bias_correction|seq_source|index": {
-                    "id": 13,
+                    "id": 14,
                     "output_name": "out1"
                 },
                 "input": {
-                    "id": 17,
+                    "id": 18,
                     "output_name": "mapped_reads"
                 },
                 "reference_annotation|reference_annotation_file": {
@@ -2015,23 +2087,23 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "Transcripts Expression from Cufflinks",
-                    "output_name": "transcripts_expression",
-                    "uuid": "2c13ef79-948c-4f5f-8516-a769550128fd"
-                },
-                {
                     "label": "Genes Expression from Cufflinks",
                     "output_name": "genes_expression",
                     "uuid": "3bd4fbda-f241-4ebd-b7a5-dea7271c521e"
+                },
+                {
+                    "label": "Transcripts Expression from Cufflinks",
+                    "output_name": "transcripts_expression",
+                    "uuid": "2c13ef79-948c-4f5f-8516-a769550128fd"
                 }
             ]
         },
-        "23": {
+        "24": {
             "annotation": "",
-            "id": 23,
+            "id": 24,
             "input_connections": {
                 "RNA STAR count tables": {
-                    "id": 17,
+                    "id": 18,
                     "input_subworkflow_step_id": 3,
                     "output_name": "reads_per_gene"
                 },
@@ -2041,12 +2113,12 @@
                     "output_name": "output"
                 },
                 "featureCounts count table": {
-                    "id": 20,
+                    "id": 21,
                     "input_subworkflow_step_id": 4,
                     "output_name": "output_short"
                 },
                 "featureCounts summaries collection": {
-                    "id": 20,
+                    "id": 21,
                     "input_subworkflow_step_id": 1,
                     "output_name": "output_summary"
                 }
@@ -2505,46 +2577,116 @@
                     "label": "Counts Table",
                     "output_name": "Counts Table",
                     "uuid": "dfe40af6-1361-4953-aac7-fbca6cfdb47a"
-                },
-                {
-                    "label": "FeatureCounts Summary Table",
-                    "output_name": "FeatureCounts Summary Table",
-                    "uuid": "6bebc1fb-139b-4aba-82c2-4f53476f59af"
                 }
             ]
         },
-        "24": {
+        "25": {
             "annotation": "",
-            "id": 24,
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.24.1+galaxy0",
+            "errors": null,
+            "id": 25,
             "input_connections": {
-                "Cutadapt Reports": {
+                "results_0|software_cond|input": {
                     "id": 12,
-                    "input_subworkflow_step_id": 2,
-                    "output_name": "report"
+                    "output_name": "report_json"
                 },
+                "results_1|software_cond|output_0|type|input": {
+                    "id": 18,
+                    "output_name": "output_log"
+                },
+                "results_1|software_cond|output_1|type|input": {
+                    "id": 18,
+                    "output_name": "reads_per_gene"
+                },
+                "results_2|software_cond|input": {
+                    "id": 24,
+                    "output_name": "FeatureCounts Summary Table"
+                },
+                "when": {
+                    "id": 13,
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "inputs": [],
+            "label": "Combined MultiQC without additional QC",
+            "name": "MultiQC",
+            "outputs": [
+                {
+                    "name": "html_report",
+                    "type": "html"
+                },
+                {
+                    "name": "stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2405.2752524038633,
+                "top": 15.83131975019036
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.24.1+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "f7e2f1eb3a16",
+                "name": "multiqc",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"star\", \"__current_case__\": 28, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"log\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"type\": {\"type\": \"genecounts\", \"__current_case__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"featureCounts\", \"__current_case__\": 9, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.24.1+galaxy0",
+            "type": "tool",
+            "uuid": "8ad489c5-92b6-4e73-99a4-543923bea427",
+            "when": "$(inputs.when)",
+            "workflow_outputs": [
+                {
+                    "label": "Small MultiQC HTML report",
+                    "output_name": "html_report",
+                    "uuid": "91f6fe1c-d957-4e0e-83a7-757d879ffec3"
+                },
+                {
+                    "label": "Small MultiQC stats",
+                    "output_name": "stats",
+                    "uuid": "db8e150d-c55c-4554-a790-c031a35f8b45"
+                }
+            ]
+        },
+        "26": {
+            "annotation": "",
+            "id": 26,
+            "input_connections": {
                 "FASTQ collection": {
                     "id": 11,
                     "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 },
-                "STAR logs": {
-                    "id": 17,
+                "STAR gene counts": {
+                    "id": 18,
                     "input_subworkflow_step_id": 3,
+                    "output_name": "reads_per_gene"
+                },
+                "STAR logs": {
+                    "id": 18,
+                    "input_subworkflow_step_id": 2,
                     "output_name": "output_log"
                 },
                 "STAR paired-end BAM": {
-                    "id": 17,
-                    "input_subworkflow_step_id": 5,
+                    "id": 18,
+                    "input_subworkflow_step_id": 6,
                     "output_name": "mapped_reads"
                 },
-                "featureCounts summaries": {
-                    "id": 23,
+                "fastp Reports": {
+                    "id": 12,
                     "input_subworkflow_step_id": 1,
+                    "output_name": "report_json"
+                },
+                "featureCounts summaries": {
+                    "id": 24,
+                    "input_subworkflow_step_id": 4,
                     "output_name": "FeatureCounts Summary Table"
                 },
                 "reference_annotation_gtf": {
                     "id": 5,
-                    "input_subworkflow_step_id": 4,
+                    "input_subworkflow_step_id": 5,
                     "output_name": "output"
                 },
                 "when": {
@@ -2555,10 +2697,10 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Combined MultiQC Quality Report"
+                    "name": "Combined MultiQC Quality Report with additional QC"
                 }
             ],
-            "label": "Combined MultiQC Quality Report",
+            "label": "Combined MultiQC Quality Report with additional QC",
             "name": "RNA-seq-Paired-QC",
             "outputs": [],
             "position": {
@@ -2599,8 +2741,8 @@
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 0,
-                            "top": 0
+                            "left": 0.0,
+                            "top": 50.38988268780724
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -2611,50 +2753,23 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "featureCounts Summaries file",
+                        "annotation": "fastp Reports",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "featureCounts Summaries file",
-                                "name": "featureCounts summaries"
+                                "description": "fastp Reports",
+                                "name": "fastp Reports"
                             }
                         ],
-                        "label": "featureCounts summaries",
+                        "label": "fastp Reports",
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 21.653447845324965,
-                            "top": 474.2009198740476
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
-                        "tool_version": null,
-                        "type": "data_collection_input",
-                        "uuid": "5a5cb076-92cb-48bd-80e0-d7bfa19fe969",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "2": {
-                        "annotation": "Cutadapt Reports",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 2,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "Cutadapt Reports",
-                                "name": "Cutadapt Reports"
-                            }
-                        ],
-                        "label": "Cutadapt Reports",
-                        "name": "Input dataset collection",
-                        "outputs": [],
-                        "position": {
-                            "left": 561.109657767363,
-                            "top": 318.00000311286055
+                            "left": 134.80355171857803,
+                            "top": 181.47189808543578
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -2664,11 +2779,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "3": {
+                    "2": {
                         "annotation": "STAR log files",
                         "content_id": null,
                         "errors": null,
-                        "id": 3,
+                        "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -2680,8 +2795,8 @@
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 568.1890947745617,
-                            "top": 448.0768645395773
+                            "left": 218.26764632413384,
+                            "top": 291.7068715859467
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -2691,11 +2806,65 @@
                         "when": null,
                         "workflow_outputs": []
                     },
+                    "3": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "STAR gene counts"
+                            }
+                        ],
+                        "label": "STAR gene counts",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 282.5174775510844,
+                            "top": 388.3856046156558
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "65ca0df2-1764-4605-8485-56633366ed5d",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
                     "4": {
-                        "annotation": "Reference annotation",
+                        "annotation": "featureCounts Summaries file",
                         "content_id": null,
                         "errors": null,
                         "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "featureCounts Summaries file",
+                                "name": "featureCounts summaries"
+                            }
+                        ],
+                        "label": "featureCounts summaries",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 351.6280284762066,
+                            "top": 524.3280615905143
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "5a5cb076-92cb-48bd-80e0-d7bfa19fe969",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "Reference annotation",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 5,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -2707,8 +2876,8 @@
                         "name": "Input dataset",
                         "outputs": [],
                         "position": {
-                            "left": 2.1095586103713773,
-                            "top": 757.9999851090132
+                            "left": 414.3587638558393,
+                            "top": 727.1586541357461
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -2718,11 +2887,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "5": {
+                    "6": {
                         "annotation": "Mapped BAM files from STAR",
                         "content_id": null,
                         "errors": null,
-                        "id": 5,
+                        "id": 6,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -2734,8 +2903,8 @@
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 1.1095706393493272,
-                            "top": 907.0000031128606
+                            "left": 413.35877588481725,
+                            "top": 876.1586721395935
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -2745,11 +2914,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "6": {
+                    "7": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
                         "errors": null,
-                        "id": 6,
+                        "id": 7,
                         "input_connections": {
                             "input_file": {
                                 "id": 0,
@@ -2783,10 +2952,21 @@
                             }
                         ],
                         "position": {
-                            "left": 560.0000308495477,
-                            "top": 1.999988137762914
+                            "left": 639.7276714482445,
+                            "top": 0.0
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionhtml_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "html_file"
+                            },
+                            "HideDatasetActiontext_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "text_file"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
                         "tool_shed_repository": {
                             "changeset_revision": "2c64fded1286",
@@ -2801,14 +2981,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "7": {
+                    "8": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gtftobed12/gtftobed12/357",
                         "errors": null,
-                        "id": 7,
+                        "id": 8,
                         "input_connections": {
                             "gtf_file": {
-                                "id": 4,
+                                "id": 5,
                                 "output_name": "output"
                             }
                         },
@@ -2822,10 +3002,16 @@
                             }
                         ],
                         "position": {
-                            "left": 281.10957032320283,
-                            "top": 743.0000031128606
+                            "left": 693.3587755686708,
+                            "top": 712.1586721395935
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionbed_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "bed_file"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gtftobed12/gtftobed12/357",
                         "tool_shed_repository": {
                             "changeset_revision": "b026dae67fba",
@@ -2840,14 +3026,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "8": {
+                    "9": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.20+galaxy3",
                         "errors": null,
-                        "id": 8,
+                        "id": 9,
                         "input_connections": {
                             "input": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "output"
                             }
                         },
@@ -2861,10 +3047,16 @@
                             }
                         ],
                         "position": {
-                            "left": 281.10934435907967,
-                            "top": 895.3505751212938
+                            "left": 693.3585496045475,
+                            "top": 864.5092441480267
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionoutputsam": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outputsam"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.20+galaxy3",
                         "tool_shed_repository": {
                             "changeset_revision": "32dc5f781059",
@@ -2879,14 +3071,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "9": {
+                    "10": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.5",
                         "errors": null,
-                        "id": 9,
+                        "id": 10,
                         "input_connections": {
                             "input": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "output"
                             }
                         },
@@ -2900,10 +3092,16 @@
                             }
                         ],
                         "position": {
-                            "left": 281.1095878752642,
-                            "top": 1102.0000031128604
+                            "left": 693.3587931207321,
+                            "top": 1071.1586721395934
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.5",
                         "tool_shed_repository": {
                             "changeset_revision": "fa5d3e61e429",
@@ -2918,14 +3116,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "10": {
+                    "11": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
                         "errors": null,
-                        "id": 10,
+                        "id": 11,
                         "input_connections": {
                             "inputFile": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "output"
                             }
                         },
@@ -2943,10 +3141,21 @@
                             }
                         ],
                         "position": {
-                            "left": 279.4598772618595,
-                            "top": 1252.3383843362294
+                            "left": 691.7090825073274,
+                            "top": 1221.4970533629626
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionmetrics_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "metrics_file"
+                            },
+                            "HideDatasetActionoutFile": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outFile"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
                         "tool_shed_repository": {
                             "changeset_revision": "3f254c5ced1d",
@@ -2961,18 +3170,18 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "11": {
+                    "12": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/5.0.3+galaxy0",
                         "errors": null,
-                        "id": 11,
+                        "id": 12,
                         "input_connections": {
                             "input": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "output"
                             },
                             "refgene": {
-                                "id": 7,
+                                "id": 8,
                                 "output_name": "bed_file"
                             }
                         },
@@ -2986,10 +3195,16 @@
                             }
                         ],
                         "position": {
-                            "left": 551.1095706393493,
-                            "top": 634.0000031128606
+                            "left": 963.3587758848173,
+                            "top": 603.1586721395935
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/5.0.3+galaxy0",
                         "tool_shed_repository": {
                             "changeset_revision": "27e16a30667a",
@@ -3004,18 +3219,18 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "12": {
+                    "13": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/5.0.3+galaxy0",
                         "errors": null,
-                        "id": 12,
+                        "id": 13,
                         "input_connections": {
                             "batch_mode|input": {
-                                "id": 8,
+                                "id": 9,
                                 "output_name": "outputsam"
                             },
                             "refgene": {
-                                "id": 7,
+                                "id": 8,
                                 "output_name": "bed_file"
                             }
                         },
@@ -3038,10 +3253,21 @@
                             }
                         ],
                         "position": {
-                            "left": 550.109375,
-                            "top": 844
+                            "left": 962.3585802454679,
+                            "top": 813.1586690267329
                         },
-                        "post_job_actions": {},
+                        "post_job_actions": {
+                            "HideDatasetActionoutputcurvespdf": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outputcurvespdf"
+                            },
+                            "HideDatasetActionoutputtxt": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outputtxt"
+                            }
+                        },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/5.0.3+galaxy0",
                         "tool_shed_repository": {
                             "changeset_revision": "27e16a30667a",
@@ -3056,43 +3282,47 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "13": {
+                    "14": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.24.1+galaxy0",
                         "errors": null,
-                        "id": 13,
+                        "id": 14,
                         "input_connections": {
                             "results_0|software_cond|output_0|input": {
-                                "id": 6,
+                                "id": 7,
                                 "output_name": "text_file"
                             },
                             "results_1|software_cond|input": {
-                                "id": 2,
+                                "id": 1,
                                 "output_name": "output"
                             },
                             "results_2|software_cond|output_0|type|input": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "results_2|software_cond|output_1|type|input": {
                                 "id": 3,
                                 "output_name": "output"
                             },
-                            "results_3|software_cond|output_0|type|input": {
-                                "id": 11,
+                            "results_3|software_cond|input": {
+                                "id": 4,
                                 "output_name": "output"
                             },
-                            "results_4|software_cond|output_0|input": {
-                                "id": 10,
-                                "output_name": "metrics_file"
-                            },
-                            "results_5|software_cond|output_0|type|input": {
+                            "results_4|software_cond|output_0|type|input": {
                                 "id": 12,
+                                "output_name": "output"
+                            },
+                            "results_4|software_cond|output_1|type|input": {
+                                "id": 13,
                                 "output_name": "outputtxt"
                             },
-                            "results_6|software_cond|output_0|type|input": {
-                                "id": 9,
+                            "results_5|software_cond|output_0|type|input": {
+                                "id": 10,
                                 "output_name": "output"
                             },
-                            "results_7|software_cond|input": {
-                                "id": 1,
-                                "output_name": "output"
+                            "results_6|software_cond|output_0|input": {
+                                "id": 11,
+                                "output_name": "metrics_file"
                             }
                         },
                         "inputs": [],
@@ -3109,8 +3339,8 @@
                             }
                         ],
                         "position": {
-                            "left": 871.1096398991552,
-                            "top": 404.00000311286055
+                            "left": 1326.7698466852496,
+                            "top": 452.11475989525854
                         },
                         "post_job_actions": {
                             "RenameDatasetActionhtml_report": {
@@ -3135,7 +3365,7 @@
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"star\", \"__current_case__\": 28, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"log\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"rseqc\", \"__current_case__\": 22, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"read_distribution\", \"__current_case__\": 6, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"picard\", \"__current_case__\": 17, \"output\": [{\"__index__\": 0, \"type\": \"markdups\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"rseqc\", \"__current_case__\": 22, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"gene_body_coverage\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"idxstats\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 7, \"software_cond\": {\"software\": \"featureCounts\", \"__current_case__\": 9, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"title\": \"Combined Quality Report \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"star\", \"__current_case__\": 28, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"log\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"type\": {\"type\": \"genecounts\", \"__current_case__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"featureCounts\", \"__current_case__\": 9, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"rseqc\", \"__current_case__\": 22, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"read_distribution\", \"__current_case__\": 6, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"type\": {\"type\": \"gene_body_coverage\", \"__current_case__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"idxstats\", \"__current_case__\": 2, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"picard\", \"__current_case__\": 17, \"output\": [{\"__index__\": 0, \"type\": \"markdups\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}], \"title\": \"Combined Quality Report \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "1.24.1+galaxy0",
                         "type": "tool",
                         "uuid": "b5e9c0d2-62f4-41b2-a1c7-5677d8555fd4",
@@ -3155,7 +3385,7 @@
                     }
                 },
                 "tags": [],
-                "uuid": "8518a66b-6e91-4252-a543-0109bf7bb75e"
+                "uuid": "7a36b35e-4487-49d8-b6e1-45a2063a5fff"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -3179,6 +3409,6 @@
         "RNAseq",
         "transcriptomics"
     ],
-    "uuid": "3eb40117-2053-4cab-ba1d-d4e31d8b997f",
-    "version": 20
+    "uuid": "541ebcef-a7ea-42de-8597-97a18555eaab",
+    "version": 6
 }

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
@@ -79,7 +79,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.10",
+    "release": "1.0",
     "name": "RNA-seq for Paired-end fastqs",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
@@ -4,27 +4,6 @@
     "comments": [
         {
             "child_steps": [
-                14,
-                22,
-                23
-            ],
-            "color": "yellow",
-            "data": {
-                "title": "Additional quantification"
-            },
-            "id": 2,
-            "position": [
-                1391.2086321940171,
-                1073.6999999999998
-            ],
-            "size": [
-                860,
-                716
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
                 15,
                 16,
                 17
@@ -61,6 +40,27 @@
             "size": [
                 375,
                 538
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                14,
+                22,
+                23
+            ],
+            "color": "yellow",
+            "data": {
+                "title": "Additional quantification"
+            },
+            "id": 2,
+            "position": [
+                1391.2086321940171,
+                1073.6999999999998
+            ],
+            "size": [
+                860,
+                716
             ],
             "type": "frame"
         }
@@ -1971,7 +1971,7 @@
         },
         "23": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.4",
             "errors": null,
             "id": 23,
             "input_connections": {
@@ -2008,6 +2008,10 @@
                 {
                     "description": "runtime parameter for tool Cufflinks",
                     "name": "advanced_settings"
+                },
+                {
+                    "description": "runtime parameter for tool Cufflinks",
+                    "name": "input"
                 },
                 {
                     "description": "runtime parameter for tool Cufflinks",
@@ -2073,15 +2077,15 @@
                     "output_name": "transcripts_expression"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.4",
             "tool_shed_repository": {
-                "changeset_revision": "d080005cffe1",
+                "changeset_revision": "6926716bbfb5",
                 "name": "cufflinks",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"advanced_settings\": {\"use_advanced_settings\": \"Yes\", \"__current_case__\": 1, \"library_type\": {\"__class__\": \"ConnectedValue\"}, \"mask_file\": {\"__class__\": \"ConnectedValue\"}, \"inner_mean_dist\": \"200\", \"inner_dist_std_dev\": \"80\", \"max_mle_iterations\": \"5000\", \"junc_alpha\": \"0.001\", \"small_anchor_fraction\": \"0.09\", \"overhang_tolerance\": \"8\", \"max_bundle_length\": \"10000000\", \"max_bundle_frags\": \"1000000\", \"min_intron_length\": \"50\", \"trim_three_avgcov_thresh\": \"10\", \"trim_three_dropoff_frac\": \"0.1\"}, \"bias_correction\": {\"do_bias_correction\": \"Yes\", \"__current_case__\": 0, \"seq_source\": {\"index_source\": \"cached\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}}, \"global_model\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"length_correction\": \"--no-effective-length-correction\", \"max_intron_len\": \"300000\", \"min_isoform_fraction\": \"0.1\", \"multiread_correct\": true, \"pre_mrna_fraction\": \"0.15\", \"reference_annotation\": {\"use_ref\": \"Use reference annotation\", \"__current_case__\": 1, \"reference_annotation_file\": {\"__class__\": \"ConnectedValue\"}, \"compatible_hits_norm\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.2.1.3",
+            "tool_state": "{\"advanced_settings\": {\"use_advanced_settings\": \"Yes\", \"__current_case__\": 1, \"library_type\": {\"__class__\": \"ConnectedValue\"}, \"mask_file\": {\"__class__\": \"RuntimeValue\"}, \"inner_mean_dist\": \"200\", \"inner_dist_std_dev\": \"80\", \"max_mle_iterations\": \"5000\", \"junc_alpha\": \"0.001\", \"small_anchor_fraction\": \"0.09\", \"overhang_tolerance\": \"8\", \"max_bundle_length\": \"10000000\", \"max_bundle_frags\": \"1000000\", \"min_intron_length\": \"50\", \"trim_three_avgcov_thresh\": \"10\", \"trim_three_dropoff_frac\": \"0.1\"}, \"bias_correction\": {\"do_bias_correction\": \"Yes\", \"__current_case__\": 0, \"seq_source\": {\"index_source\": \"cached\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}}, \"global_model\": null, \"input\": {\"__class__\": \"RuntimeValue\"}, \"length_correction\": \"--no-effective-length-correction\", \"max_intron_len\": \"300000\", \"min_isoform_fraction\": \"0.1\", \"multiread_correct\": true, \"pre_mrna_fraction\": \"0.15\", \"reference_annotation\": {\"use_ref\": \"Use reference annotation\", \"__current_case__\": 1, \"reference_annotation_file\": {\"__class__\": \"RuntimeValue\"}, \"compatible_hits_norm\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.2.1.4",
             "type": "tool",
             "uuid": "af5419b7-ae6b-498c-8123-f609b8fcd8b4",
             "when": "$(inputs.when)",
@@ -2632,7 +2636,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"star\", \"__current_case__\": 28, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"log\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"type\": {\"type\": \"genecounts\", \"__current_case__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"featureCounts\", \"__current_case__\": 9, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"star\", \"__current_case__\": 28, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"log\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"type\": {\"type\": \"genecounts\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"featureCounts\", \"__current_case__\": 9, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.24.1+galaxy0",
             "type": "tool",
             "uuid": "8ad489c5-92b6-4e73-99a4-543923bea427",
@@ -3409,6 +3413,6 @@
         "RNAseq",
         "transcriptomics"
     ],
-    "uuid": "541ebcef-a7ea-42de-8597-97a18555eaab",
-    "version": 6
+    "uuid": "5ab1d724-01d4-4673-a3c3-ae2bc944458f",
+    "version": 1
 }


### PR DESCRIPTION
This PR:
- Fixed the tests (missing asserts)
- use fastp instead of cutadapt which allows optional adapters
- generate a combined report if additional QC are not wanted
- include the gene counts from STAR in the multiQC
- hide more intermediate outputs
- do not consider FeatureCounts Summary Table as a workflow output